### PR TITLE
Add avatar to bot in sample

### DIFF
--- a/sample/backend/models.go
+++ b/sample/backend/models.go
@@ -82,7 +82,10 @@ func DefaultAppState() *AppState {
 		Channels: make(map[string]*Channel, 0),
 		Users:    make(map[string]*User, 0),
 	}
-	bot := &User{Name: "SpeakeasyBot"}
+	bot := &User{
+		Name: "SpeakeasyBot",
+		ImageUrl: GetAsset("assets/avatars/justice.png").Url(),
+	}
 	state.PutUser(bot)
 
 	general := &Channel{Name: "#general", Messages: []*Message{}}

--- a/sample/backend/models_test.go
+++ b/sample/backend/models_test.go
@@ -7,10 +7,10 @@ import (
 )
 
 func TestDefaultChannels(t *testing.T) {
-	server := NewServer()
+	engine := NewEngine()
 
 	output, err := json.MarshalIndent(&ChannelsResponse{
-		Channels: server.AppState.ChannelNameList(),
+		Channels: engine.AppState.ChannelNameList(),
 	}, "", "    ")
 	if err != nil {
 		fmt.Println(err)
@@ -29,10 +29,10 @@ func TestDefaultChannels(t *testing.T) {
 }
 
 func TestDefaultUsers(t *testing.T) {
-	server := NewServer()
+	engine := NewEngine()
 
-	channel := server.AppState.Channels["#general"]
-	output, err := json.MarshalIndent(channel.UserList(server.AppState), "", "    ")
+	channel := engine.AppState.Channels["#general"]
+	output, err := json.MarshalIndent(channel.UserList(engine.AppState), "", "    ")
 	if err != nil {
 		fmt.Println(err)
 	}
@@ -41,7 +41,7 @@ func TestDefaultUsers(t *testing.T) {
 	expected := `[
     {
         "name": "SpeakeasyBot",
-        "image_url": ""
+        "image_url": "http://localhost:3000/assets/assets/avatars/justice.png"
     }
 ]`
 	if expected != string(output) {


### PR DESCRIPTION
The image was not used anywhere before, now it's used as the image for the bot avatar.

Also fixed the sample backend tests.